### PR TITLE
Finish work on the Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,18 @@
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_dir := $(dir $(realpath $(mkfile_path)))
+dockerfile_dir := $(project_dir)/dockerfile
 
 author ?= "Canonical IS team"
 revision ?= $(shell git -C $(project_dir) rev-parse HEAD)
-date_created ?= $(shell date +'%Y%m%d%H%M')
+date_created ?= $(shell date +'%Y%m%d')
 
-
-build-image:
+build-image: | $(dockerfile_dir)
 	docker build \
 	  --build-arg DATE_CREATED="$(date_created)" \
 	  --build-arg AUTHOR=$(author) \
 	  --build-arg REVISION="$(revision)" \
-	  -t jenkins-slave-operator:$(revision) $(project_dir)
+	  -t jenkins-slave-operator:$(revision) $(dockerfile_dir)
+
+build-image-dev: | $(dockerfile_dir)
+	docker build -t jenkins-slave-operator:devel $(dockerfile_dir)

--- a/README.md
+++ b/README.md
@@ -13,8 +13,26 @@ Link the framework:
 ln -s ../mod/operator/ops lib/ops
 ```
 
-
 Update the operator submodule:
 ```
 git submodule update --init
+```
+
+## Testing the docker image
+
+```
+juju deploy jenkins
+```
+
+Go create a node on the jenkins master called "jenkins-slave-test" manually for now
+
+```
+API_TOKEN=$(juju ssh 0 -- sudo cat /var/lib/jenkins/.admin_token)
+JENKINS_IP=$(juju status --format json jenkins | jq -r '.machines."0"."ip-addresses"[0]')
+make build-image-dev
+docker run --rm -ti --name jenkins-slave-test \
+ -e JENKINS_API_USER=admin \
+ -e JENKINS_API_TOKEN="${API_TOKEN}" \
+ -e JENKINS_URL="http://${JENKINS_IP}:8080" \
+ -e JENKINS_HOSTNAME="jenkins-slave-test" jenkins-slave-operator:devel
 ```

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -1,13 +1,12 @@
 ARG DIST_RELEASE=focal
 FROM ubuntu:${DIST_RELEASE}
 
+ENTRYPOINT /entrypoint.sh
+
 ARG DIST_RELEASE_VERSION=20.04
 
 LABEL com.canonical.dist-release=${DIST_RELEASE}
 LABEL com.canonical.dist-release=${DIST_RELEASE_VERSION}
-
-ARG DATE_CREATED
-LABEL org.opencontainers.image.created=${DATE_CREATED}
 
 ARG AUTHOR
 LABEL org.opencontainers.image.authors=${OCI_AUTHOR}
@@ -16,13 +15,8 @@ LABEL org.opencontainers.image.url="https://github.com/canonical/jenkins-slave-o
 LABEL org.opencontainers.image.documentation="https://github.com/canonical/jenkins-slave-operator"
 LABEL org.opencontainers.image.source="https://github.com/canonical/jenkins-slave-operator"
 LABEL org.opencontainers.image.version="0.0.1"
-
-ARG REVISION
-LABEL org.opencontainers.image.revision=${REVISION}
-
 LABEL org.opencontainers.image.vendor="Canonical"
 LABEL org.opencontainers.image.licenses="Apache"
-
 
 # Ensure that the needed directory are owned by the right user
 ARG USER=jenkins
@@ -47,8 +41,18 @@ VOLUME /var/log/jenkins
 # Install runtime requirements
 RUN apt-get update -y \
 	&& apt-get install -y \
-		default-jre-headless \
-		wget
+		curl \
+		default-jre-headless
+
 
 WORKDIR /var/lib/jenkins
+
 USER ${USER}
+
+COPY files/entrypoint.sh /
+
+ARG DATE_CREATED=devel
+LABEL org.opencontainers.image.created=${DATE_CREATED}
+
+ARG REVISION=devel
+LABEL org.opencontainers.image.revision=${REVISION}

--- a/dockerfile/files/entrypoint.sh
+++ b/dockerfile/files/entrypoint.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+export LC_ALL=C
+
+# defaults for jenkins-slave component of the jenkins continuous integration
+# system
+
+# location of java
+typeset JAVA=/usr/bin/java
+
+# arguments to pass to java - optional
+# Just set this variable with whatever you want to add as an environment variable
+# i.e JAVA_ARGS="-Xms 256m"
+typeset JAVA_ARGS=${JAVA_ARGS:-""}
+
+# URL of jenkins server to connect to
+# Not specifying this parameter will stop the slave
+# job from running.
+typeset JENKINS_URL="${JENKINS_URL:?"URL of a jenkins server must be provided"}"
+
+# Name of slave configuration to use at JENKINS_URL
+# Override if it need to be something other than the
+# hostname of the server the slave is running on.
+typeset JENKINS_HOSTNAME="${JENKINS_HOSTNAME:-$(hostname)}"
+
+# Arguments to pass to jenkins slave on startup
+typeset -a JENKINS_ARGS
+
+JENKINS_ARGS+=(-jnlpUrl "${JENKINS_URL}"/computer/"${JENKINS_HOSTNAME}"/slave-agent.jnlp)
+JENKINS_ARGS+=(-jnlpCredentials "${JENKINS_API_USER}:${JENKINS_API_TOKEN}")
+
+# Path of the agent.jar
+typeset AGENT_JAR=/var/lib/jenkins/agent.jar
+
+download_agent() {
+    ## Download the agent.jar
+
+    # Retrieve Slave JAR from Master Server
+    echo "Downloading agent.jar from ${JENKINS_URL}..."
+    curl -L -s -o "${AGENT_JAR}".new "${JENKINS_URL}"/jnlpJars/agent.jar
+
+    # Check to make sure slave.jar was downloaded.
+    if [[ -s "${AGENT_JAR}".new ]]; then
+        mv "${AGENT_JAR}".new "${AGENT_JAR}"
+    else
+        echo "Error while downloading ${AGENT_JAR}"
+        exit 1
+    fi
+}
+
+download_agent
+
+#shellcheck disable=SC2086
+"${JAVA}" ${JAVA_ARGS} -jar "${AGENT_JAR}"  "${JENKINS_ARGS[@]}"


### PR DESCRIPTION
* Add the entrypoint.sh needed to download the agent.jar and start it

* Adapt the Makefile to add a target to build a devel image, with
  a dummy creation date and a dummy tag for faster iteration

* Put the bits that will change the most
  (some labels and the entrypoint) at the end for better caching usage

To test you can do the following

 .. code::

   juju deploy jenkins
   # Go create a node on the jenkins master called "jenkins-slave-test"
   API_TOKEN=$(juju ssh 0 -- sudo cat /var/lib/jenkins/.admin_token)
   JENKINS_IP=$(juju status --format json jenkins | jq -r '.machines."0"."ip-addresses"[0]')
   make build-image-dev
   docker run --rm -ti --name jenkins-slave-test \
    -e JENKINS_API_USER=admin \
    -e JENKINS_API_TOKEN="${API_TOKEN}" \
    -e JENKINS_URL="http://${JENKINS_IP}:8080" \
    -e JENKINS_HOSTNAME="jenkins-slave-test" jenkins-slave-operator:devel

TODO:

* The jenkins/jenkins-slave relation is used to create a node with a
  dedicated name, necessary for the script to start up.
  The docker image will have to have a daemon maintaining the pod alive
  and the relation should fire the entrypoint.sh script